### PR TITLE
Also track open files using eBPF

### DIFF
--- a/dist/install.sh
+++ b/dist/install.sh
@@ -49,6 +49,10 @@ systemd_install() {
 	systemctl restart edgebit-agent
 }
 
+if [ "$arch" != "x86_64" ]; then
+	die "Only x86_64 is supported at this time"
+fi
+
 if [ $(whoami) != "root" ]; then
 	die "Please run as root"
 fi


### PR DESCRIPTION
This brings back hooking open/exec family of syscalls to catch events that happen before the container is detected as running.