### PR TITLE
Fix container file in-use reporting

### DIFF
--- a/src/agent/config.rs
+++ b/src/agent/config.rs
@@ -99,7 +99,6 @@ impl Config {
         self.inner.syft_config.clone()
     }
 
-
     pub fn syft_path(&self) -> PathBuf {
         self.inner.syft_path.clone()
     }

--- a/src/agent/fanotify.rs
+++ b/src/agent/fanotify.rs
@@ -85,7 +85,7 @@ impl Fanotify {
                 },
                 Ok(Err(err)) => {
                     match err.kind() {
-                        ErrorKind::WouldBlock => { continue; },
+                        ErrorKind::WouldBlock => continue,
                         _ => return Err(err.into()),
                     }
                 },


### PR DESCRIPTION
Along with some cleanup, this fixes a bug where the canonicalization of paths occurred before the rootfs was prepended. Since this happened on the host, it would fail for containers.