### PR TITLE
Add Kube based deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,19 @@ docker run \
   -e "EDGEBIT_URL=https://YOUR_ORG.edgebit.io" \
   edgebit-agent:latest --hostname "$(hostname)"
 ```
+
+# Kubernetes based deployment
+
+The agent can be deployed on the Kubernetes as a privileged pod running as a DaemonSet:
+
+1. Edit [config.yaml](dist/kube/config.yaml) to put configure the EdgeBit URL and your EdgeBit ID (Deployment Token).
+
+2. Apply [config.yaml](dist/kube/config.yaml):
+```
+kubectl apply -f config.yaml
+```
+
+3. Apply [daemonset.yaml](dist/kube/daemonset.yaml) to deploy the Agent:
+```
+kubectl apply -f daemonset.yaml
+```

--- a/dist/kube/config.yaml
+++ b/dist/kube/config.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: edgebit-system
+  labels: {}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edgebit-agent-config
+  namespace: edgebit-system
+  labels: {}
+data:
+  edgebit-url: https://YOUR_ORG.edgebit.io
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: edgebit-agent-api-key
+  namespace: edgebit-system
+  labels: {}
+type: Opaque
+stringData:
+  edgebit-id: YOUR_EDGEBIT_ID

--- a/dist/kube/daemonset.yaml
+++ b/dist/kube/daemonset.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: edgebit-agent
+  namespace: edgebit-system
+  labels: {}
+spec:
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: edgebit-agent
+  template:
+    metadata:
+      labels:
+        app: edgebit-agent
+      name: edgebit-agent
+      annotations:
+    spec:
+      securityContext:
+        runAsUser: 0
+      hostPID: true
+      containers:
+        - name: agent
+          image: "public.ecr.aws/edgebit/edgebit-agent:0.3.0-dev"
+          imagePullPolicy: IfNotPresent
+          command:
+          resources: {}
+          ports:
+          env:
+            - name: EDGEBIT_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: edgebit-agent-config
+                  key: edgebit-url
+            - name: EDGEBIT_ID
+              valueFrom:
+                secretKeyRef:
+                    name: edgebit-agent-api-key
+                    key: edgebit-id
+                    optional: false
+            - name: EDGEBIT_HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          volumeMounts:
+            - name: host
+              mountPath: /host
+              readOnly: true
+            - name: debugfs
+              mountPath: /sys/kernel/debug
+            - name: var-edgebit
+              mountPath: /var/lib/edgebit
+          securityContext:
+            privileged: true
+      tolerations:
+      affinity: {}
+      nodeSelector:
+        kubernetes.io/os: linux
+      volumes:
+        - name: host
+          hostPath:
+            path: /
+        - name: debugfs
+          hostPath:
+            path: /sys/kernel/debug
+        - name: var-edgebit
+          hostPath:
+            path: /var/lib/edgebit
+            type: DirectoryOrCreate
+
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate

--- a/src/agent/open_monitor.rs
+++ b/src/agent/open_monitor.rs
@@ -28,9 +28,14 @@ struct BpfProbes {
 impl BpfProbes {
     fn load() -> Result<Self> {
         let skel_builder = probes::ProbesSkelBuilder::default();
-        let open_skel = skel_builder.open()?;
-        let mut skel = open_skel.load()?;
-        skel.attach()?;
+        let open_skel = skel_builder.open()
+            .map_err(|err| anyhow!("ProbesSkelBuilder::open(): {err}"))?;
+
+        let mut skel = open_skel.load()
+            .map_err(|err| anyhow!("ProbesSkelBuilder::load(): {err}"))?;
+
+        skel.attach()
+            .map_err(|err| anyhow!("ProbesSkel::attach(): {err}"))?;
 
         Ok(Self {
             skel: Arc::new(Mutex::new(skel)),
@@ -43,7 +48,8 @@ impl BpfProbes {
             .unwrap()
             .maps()
             .pid_to_info()
-            .lookup(&key, MapFlags::ANY)?;
+            .lookup(&key, MapFlags::ANY)
+            .map_err(|err| anyhow!("pid_to_info::lookup(): {err}"))?;
 
         Ok(match val {
             Some(bytes) => {
@@ -65,7 +71,8 @@ impl BpfProbes {
             .unwrap()
             .maps_mut()
             .pid_to_info()
-            .delete(pid)?;
+            .delete(pid)
+            .map_err(|err| anyhow!("pid_to_info::delete(): {err}"))?;
 
         Ok(())
     }


### PR DESCRIPTION
Adds DaemonSet based deployment. Since the modern k8s no longer uses Docker, the agent will not be able to see the containers. Support for CRI/containerd based introspection is coming next.