### PR TITLE
Support k8s containers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,6 +338,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "containerd-client"
+version = "0.2.0"
+source = "git+https://github.com/containerd/rust-extensions.git?rev=ba111e55aaf3829964730287ae9f96d0088b4c18#ba111e55aaf3829964730287ae9f96d0088b4c18"
+dependencies = [
+ "axum-core",
+ "prost",
+ "prost-types",
+ "tokio",
+ "tonic",
+ "tonic-build",
+ "tower",
+]
+
+[[package]]
 name = "containers-api"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,6 +446,7 @@ dependencies = [
  "bytes 1.4.0",
  "chrono",
  "clap",
+ "containerd-client",
  "fanotify-rs",
  "futures",
  "gethostname",
@@ -454,6 +469,7 @@ dependencies = [
  "tokio",
  "tonic",
  "tonic-build",
+ "tower",
  "uuid",
 ]
 
@@ -544,7 +560,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1078,7 +1094,7 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1870,9 +1886,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.25.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
+checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
 dependencies = [
  "autocfg",
  "bytes 1.4.0",
@@ -1884,7 +1900,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2342,21 +2358,6 @@ name = "windows"
 version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04662ed0e3e5630dfa9b26e4cb823b817f1a9addda855d973a9458c236556244"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,12 @@ clap = { version = "3.0", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["std"] }
 json = "0.12"
-tokio = { version = "1.23", features = ["macros", "rt", "rt-multi-thread", "net", "signal", "sync"] }
+tokio = { version = "1.26", features = ["macros", "rt", "rt-multi-thread", "net", "signal", "sync"] }
 bytes = "1.3"
 bytemuck = { version = "1.12", features = ["derive"] }
 prost = "0.11"
 prost-types = "0.11"
+tower = "0.4"
 tonic = { version = "0.8", features = ["transport", "tls", "tls-webpki-roots"] }
 gethostname = "0.4"
 libbpf-rs = { version = "0.19.1", features = ["static"] }
@@ -28,6 +29,7 @@ rs-release = "0.1.9"
 uuid = { version = "1.3.0", features = ["v4"] }
 bollard = "0.14"
 podman-api = "0.9"
+containerd-client = { git = "https://github.com/containerd/rust-extensions.git", rev = "ba111e55aaf3829964730287ae9f96d0088b4c18" }
 lazy_static = "1.4"
 regex = "1.7"
 fanotify-rs = { git = "https://github.com/eyakubovich/fanotify-rs.git", rev = "aca76327e9c1550057e831275354d00104222b3a" }

--- a/dist/kube/daemonset.yaml
+++ b/dist/kube/daemonset.yaml
@@ -21,7 +21,7 @@ spec:
       hostPID: true
       containers:
         - name: agent
-          image: "public.ecr.aws/edgebit/edgebit-agent:0.3.0-dev"
+          image: "public.ecr.aws/edgebit/edgebit-agent:0.3.0-dev4"
           imagePullPolicy: IfNotPresent
           command:
           resources: {}
@@ -42,6 +42,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DOCKER_HOST
+              value: ""
+            - name: EDGEBIT_CONTAINERD_HOST
+              value: "unix:///host/run/containerd/containerd.sock"
           volumeMounts:
             - name: host
               mountPath: /host

--- a/src/agent/config.rs
+++ b/src/agent/config.rs
@@ -29,6 +29,8 @@ struct Inner {
 
     docker_host: Option<String>,
 
+    containerd_host: Option<String>,
+
     hostname: Option<String>,
 }
 
@@ -162,13 +164,29 @@ impl Config {
         self.try_syft_path().unwrap()
     }
 
-    pub fn docker_host(&self) -> String {
+    pub fn docker_host(&self) -> Option<String> {
         if let Ok(host) = std::env::var("DOCKER_HOST") {
-            host
+            if host.is_empty() {
+                None
+            } else {
+                Some(host)
+            }
         } else {
             self.inner.docker_host
                 .clone()
-                .unwrap_or_else(|| DEFAULT_DOCKER_HOST.to_string())
+                .or_else(|| Some(DEFAULT_DOCKER_HOST.to_string()))
+        }
+    }
+
+    pub fn containerd_host(&self) -> Option<String> {
+        if let Ok(host) = std::env::var("EDGEBIT_CONTAINERD_HOST") {
+            if host.is_empty() {
+                None
+            } else {
+                Some(host)
+            }
+        } else {
+            self.inner.containerd_host.clone()
         }
     }
 

--- a/src/agent/containers/k8s_containerd.rs
+++ b/src/agent/containers/k8s_containerd.rs
@@ -1,0 +1,329 @@
+use std::time::{SystemTime, Duration};
+use std::collections::HashMap;
+
+use anyhow::{Result, anyhow};
+use log::*;
+use tonic::transport::channel::Channel;
+use tonic::Request;
+use containerd_client::with_namespace;
+use containerd_client::services::v1::{SubscribeRequest, ListTasksRequest, GetContainerRequest, Container, ListContainersRequest, GetImageRequest};
+use containerd_client::types::v1::Status;
+use containerd_client::services::v1::events_client::EventsClient;
+use containerd_client::services::v1::containers_client::ContainersClient;
+use containerd_client::services::v1::images_client::ImagesClient;
+use containerd_client::services::v1::tasks_client::TasksClient;
+
+use containerd_client::events::*;
+use prost::DecodeError;
+use prost_types::Any;
+
+use super::{ContainerEventsPtr, ContainerInfo};
+use crate::scoped_path::*;
+
+const NAMESPACE: &str = "k8s.io";
+
+const CONTAINER_LABEL_KIND: &str = "io.cri-containerd.kind";
+const CONTAINER_LABEL_NAME: &str = "io.kubernetes.container.name";
+const CONTAINER_LABEL_POD_NAME: &str = "io.kubernetes.pod.name";
+const CONTAINER_LABEL_NAMESPACE: &str = "io.kubernetes.pod.namespace";
+
+#[derive(Clone)]
+pub struct K8sContainerdTracker {
+    containers: ContainersClient<Channel>,
+    tasks: TasksClient<Channel>,
+    events: EventsClient<Channel>,
+    images: ImagesClient<Channel>,
+}
+
+impl K8sContainerdTracker {
+    pub async fn connect(host: &str) -> Self {
+        let mut quiet = false;
+        let ch = loop {
+            match super::grpc_connect(host).await {
+                Ok(ch) => {
+                    info!("Connected to containerd daemon");
+                    break ch;
+                },
+                Err(err) => {
+                    if quiet {
+                        debug!("Failed to connect to containerd daemon: {err}");
+                    } else {
+                        error!("Failed to connect to containerd daemon: {err}");
+                        quiet = true;
+                    }
+
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                }
+            }
+        };
+
+        Self{
+            containers: ContainersClient::new(ch.clone()),
+            tasks: TasksClient::new(ch.clone()),
+            events: EventsClient::new(ch.clone()),
+            images: ImagesClient::new(ch.clone()),
+        }
+    }
+
+    pub async fn track(mut self, events: ContainerEventsPtr) -> Result<()> {
+        let events_task = tokio::task::spawn(
+            self.clone().stream_events(events.clone())
+        );
+
+        // Load already running containers
+        self.load_running(events.clone()).await?;
+
+        events.flush().await;
+
+        if let Err(err) = events_task.await.unwrap() {
+            error!("Events streaming: {err}");
+        }
+        Ok(())
+    }
+
+    async fn stream_events(mut self, events: ContainerEventsPtr) -> Result<()> {
+        let req = SubscribeRequest{
+            filters: Vec::new(),
+        };
+
+        let req = with_namespace!(req, NAMESPACE);
+
+        let mut stream = self.events.subscribe(req)
+            .await?
+            .into_inner();
+
+        while let Some(msg) = stream.message().await? {
+            if let Some(event) = msg.event {
+                match ContainerdEvent::try_from(event) {
+                    Ok(event) => self.process_event(event, events.clone()).await,
+                    Err(err) => error!("Event decoding error: {err}"),
+                }
+            }
+        }
+
+        debug!("containerd event streaming done");
+        Ok(())
+    }
+
+    async fn process_event(&mut self, event: ContainerdEvent, events: ContainerEventsPtr) {
+        match event {
+            ContainerdEvent::TaskCreate(msg) => {
+                debug!("Container {} created", msg.container_id);
+                match self.inspect_container(&msg.container_id).await {
+                    Ok(Some(info)) => {
+                        events.container_started(msg.container_id, info).await;
+                    },
+                    Ok(None) => (),
+                    Err(err) => {
+                        error!("Failed to inspect container(id={}): {err}", msg.container_id);
+                        return;
+                    }
+                }
+            },
+            ContainerdEvent::TaskDelete(msg) => {
+                let end_time = msg.exited_at
+                    .and_then(|t| t.try_into().ok())
+                    .unwrap_or(SystemTime::now());
+
+                events.container_stopped(msg.container_id, end_time).await;
+            },
+            _ => (),
+        }
+    }
+
+    async fn load_running(&mut self, events: ContainerEventsPtr) -> Result<()> {
+        let mut containers = self.load_containers().await?;
+
+        let req = ListTasksRequest {
+            filter: String::new()
+        };
+
+        let req = with_namespace!(req, NAMESPACE);
+
+        let resp = self.tasks.list(req)
+            .await?
+            .into_inner();
+
+        for t in resp.tasks {
+            if Status::from_i32(t.status) == Some(Status::Running) {
+                if let Some(info) = containers.remove(&t.id) {
+                    events.add_container(t.container_id, info);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn load_containers(&mut self) -> Result<HashMap<String, ContainerInfo>> {
+        let req = ListContainersRequest{
+            filters: Vec::new(),
+        };
+
+
+        let req = with_namespace!(req, NAMESPACE);
+
+        let resp = self.containers.list(req)
+            .await?
+            .into_inner();
+
+        let mut map = HashMap::new();
+
+        for c in resp.containers {
+            if !is_container(&c) {
+                continue;
+            }
+
+            let (id, ci) = self.into_container_info(c).await;
+            map.insert(id, ci);
+        }
+
+        Ok(map)
+    }
+
+    async fn inspect_container(&mut self, id: &str) -> Result<Option<ContainerInfo>> {
+        let req = GetContainerRequest{
+            id: id.to_string(),
+        };
+
+        let req = with_namespace!(req, NAMESPACE);
+
+        let resp = self.containers.get(req)
+            .await?
+            .into_inner();
+
+        if let Some(c) = resp.container {
+            if !is_container(&c) {
+                return Ok(None);
+            }
+
+            let (_, ci) = self.into_container_info(c).await;
+
+            Ok(Some(ci))
+
+        } else {
+            Err(anyhow!("containers.get() missing 'container'"))
+        }
+    }
+
+    async fn get_image_digest(&mut self, name: &str) -> Result<String> {
+        let req = GetImageRequest{
+            name: name.into(),
+        };
+
+        let req = with_namespace!(req, NAMESPACE);
+
+        let resp = self.images.get(req)
+            .await?
+            .into_inner();
+
+        if let Some(image) = resp.image {
+            if let Some(target) = image.target {
+                return Ok(target.digest);
+            }
+        }
+
+        Err(anyhow!("digest missing for image {name}"))
+    }
+
+    async fn into_container_info(&mut self, mut c: Container) -> (String, ContainerInfo) {
+        let image_id = match self.get_image_digest(&c.image).await {
+            Ok(digest) => Some(digest),
+            Err(err) => {
+                error!("Failed to get digest: {err}");
+                None
+            }
+        };
+
+        let name = c.labels.remove(CONTAINER_LABEL_NAME);
+
+        // TODO: expose these as well
+        let _pod = c.labels.remove(CONTAINER_LABEL_POD_NAME);
+        let _ns = c.labels.remove(CONTAINER_LABEL_NAMESPACE);
+
+        let ci = ContainerInfo{
+            name,
+            image_id,
+            image: Some(c.image),
+            rootfs: Some(get_rootfs(&c.id)),
+            start_time: c.created_at.and_then(|t| t.try_into().ok()),
+            end_time: None,
+        };
+
+        (c.id, ci)
+    }
+}
+
+fn get_rootfs(id: &str) -> HostPath {
+    // TODO: This is far from ideal and we need to look into how to get this info from the API.
+    format!("/run/containerd/io.containerd.runtime.v2.task/k8s.io/{id}/rootfs/").into()
+}
+
+// containerd events
+#[derive(Debug)]
+enum ContainerdEvent {
+    Unknown,
+    ContainerCreate(ContainerCreate),
+    ContainerDelete(ContainerDelete),
+    ContainerUpdate(ContainerUpdate),
+    ContentDelete(ContentDelete),
+    NamespaceCreate(NamespaceCreate),
+    NamespaceDelete(NamespaceDelete),
+    NamespaceUpdate(NamespaceUpdate),
+    SnapshotCommit(SnapshotCommit),
+    SnapshotPrepare(SnapshotPrepare),
+    SnapshotRemove(SnapshotRemove),
+    TaskCheckpointed(TaskCheckpointed),
+    TaskCreate(TaskCreate),
+    TaskDelete(TaskDelete),
+    TaskExecAdded(TaskExecAdded),
+    TaskExecStarted(TaskExecStarted),
+    TaskExit(TaskExit),
+    TaskIo(TaskIo),
+    TaskOom(TaskOom),
+    TaskPaused(TaskPaused),
+    TaskResumed(TaskResumed),
+    TaskStart(TaskStart),
+}
+
+impl TryFrom<Any> for ContainerdEvent {
+    type Error = DecodeError;
+
+    fn try_from(v: Any) -> std::result::Result<Self, DecodeError> {
+        use prost::Message;
+
+        let ev = match v.type_url.as_ref() {
+            "containerd.events.ContainerCreate" => ContainerdEvent::ContainerCreate(ContainerCreate::decode(v.value.as_ref())?),
+            "containerd.events.ContainerDelete" => ContainerdEvent::ContainerDelete(ContainerDelete::decode(v.value.as_ref())?),
+            "containerd.events.ContainerUpdate" => ContainerdEvent::ContainerUpdate(ContainerUpdate::decode(v.value.as_ref())?),
+            "containerd.events.ContentDelete" => ContainerdEvent::ContentDelete(ContentDelete::decode(v.value.as_ref())?),
+            "containerd.events.NamespaceCreate" => ContainerdEvent::NamespaceCreate(NamespaceCreate::decode(v.value.as_ref())?),
+            "containerd.events.NamespaceDelete" => ContainerdEvent::NamespaceDelete(NamespaceDelete::decode(v.value.as_ref())?),
+            "containerd.events.NamespaceUpdate" => ContainerdEvent::NamespaceUpdate(NamespaceUpdate::decode(v.value.as_ref())?),
+            "containerd.events.SnapshotCommit" => ContainerdEvent::SnapshotCommit(SnapshotCommit::decode(v.value.as_ref())?),
+            "containerd.events.SnapshotPrepare" => ContainerdEvent::SnapshotPrepare(SnapshotPrepare::decode(v.value.as_ref())?),
+            "containerd.events.SnapshotRemove" => ContainerdEvent::SnapshotRemove(SnapshotRemove::decode(v.value.as_ref())?),
+            "containerd.events.TaskCheckpointed" => ContainerdEvent::TaskCheckpointed(TaskCheckpointed::decode(v.value.as_ref())?),
+            "containerd.events.TaskCreate" => ContainerdEvent::TaskCreate(TaskCreate::decode(v.value.as_ref())?),
+            "containerd.events.TaskDelete" => ContainerdEvent::TaskDelete(TaskDelete::decode(v.value.as_ref())?),
+            "containerd.events.TaskExecAdded" => ContainerdEvent::TaskExecAdded(TaskExecAdded::decode(v.value.as_ref())?),
+            "containerd.events.TaskExecStarted" => ContainerdEvent::TaskExecStarted(TaskExecStarted::decode(v.value.as_ref())?),
+            "containerd.events.TaskExit" => ContainerdEvent::TaskExit(TaskExit::decode(v.value.as_ref())?),
+            "containerd.events.TaskIo" => ContainerdEvent::TaskIo(TaskIo::decode(v.value.as_ref())?),
+            "containerd.events.TaskOom" => ContainerdEvent::TaskOom(TaskOom::decode(v.value.as_ref())?),
+            "containerd.events.TaskPaused" => ContainerdEvent::TaskPaused(TaskPaused::decode(v.value.as_ref())?),
+            "containerd.events.TaskResumed" => ContainerdEvent::TaskResumed(TaskResumed::decode(v.value.as_ref())?),
+            "containerd.events.TaskStart" => ContainerdEvent::TaskStart(TaskStart::decode(v.value.as_ref())?),
+            _ => ContainerdEvent::Unknown,
+        };
+
+        Ok(ev)
+    }
+}
+
+fn is_container(c: &Container) -> bool {
+    match c.labels.get(CONTAINER_LABEL_KIND) {
+        Some(kind) => kind == "container",
+        None => false,
+    }
+}

--- a/src/agent/workload_mgr.rs
+++ b/src/agent/workload_mgr.rs
@@ -59,7 +59,13 @@ impl WorkloadManager {
         host_workload.start_monitoring(&open_monitor);
 
         let (cont_tx, cont_rx) = tokio::sync::mpsc::channel::<ContainerEvent>(10);
-        let containers = Containers::track(config.docker_host(), cont_tx);
+        let mut containers = Containers::new(cont_tx);
+        if let Some(host) = config.docker_host() {
+            containers.track_docker(host);
+        }
+        if let Some(host) = config.containerd_host() {
+            containers.track_k8s(host);
+        }
 
         let inner = Arc::new(Inner{
             config,


### PR DESCRIPTION
containerd API was chosen due to:
- Kubelet API does not support events
- CRI API only supports events in the latest version
- K8s client API has watches but is too slow

This will work for most recent K8s distros.