### PR TITLE
Run Syft in chroot when in container

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,6 +455,7 @@ dependencies = [
  "libbpf-cargo",
  "libbpf-rs",
  "log",
+ "nix 0.26.2",
  "podman-api",
  "pretty_env_logger",
  "prost",
@@ -467,6 +468,7 @@ dependencies = [
  "serde_yaml",
  "temp-file",
  "tokio",
+ "tokio-pipe",
  "tonic",
  "tonic-build",
  "tower",
@@ -999,7 +1001,7 @@ dependencies = [
  "bitflags",
  "lazy_static",
  "libbpf-sys",
- "nix",
+ "nix 0.24.3",
  "num_enum",
  "strum_macros",
  "thiserror",
@@ -1071,6 +1073,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1112,7 +1123,21 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.6.5",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+ "memoffset 0.7.1",
+ "pin-utils",
+ "static_assertions",
 ]
 
 [[package]]
@@ -1730,6 +1755,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1922,6 +1953,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-pipe"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f213a84bffbd61b8fa0ba8a044b4bbe35d471d0b518867181e82bd5c15542784"
+dependencies = [
+ "libc",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ clap = { version = "3.0", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["std"] }
 json = "0.12"
-tokio = { version = "1.26", features = ["macros", "rt", "rt-multi-thread", "net", "signal", "sync"] }
+tokio = { version = "1.26", features = ["macros", "rt", "rt-multi-thread", "net", "signal", "sync", "fs"] }
 bytes = "1.3"
 bytemuck = { version = "1.12", features = ["derive"] }
 prost = "0.11"
@@ -37,6 +37,8 @@ chrono = { version = "0.4.23", features = ["std"] }
 serde_yaml = "0.9.17"
 realpath-ext = "0.1.2"
 async-trait = "0.1.66"
+nix = { version = "0.26", features = ["resource", "fs"] }
+tokio-pipe = "0.2.12"
 
 [build-dependencies]
 tonic-build = "0.8"

--- a/dist/kube/daemonset.yaml
+++ b/dist/kube/daemonset.yaml
@@ -21,7 +21,7 @@ spec:
       hostPID: true
       containers:
         - name: agent
-          image: "public.ecr.aws/edgebit/edgebit-agent:0.3.0-dev4"
+          image: "public.ecr.aws/edgebit/edgebit-agent:0.3.0-rc4"
           imagePullPolicy: IfNotPresent
           command:
           resources: {}

--- a/dist/syft.yaml
+++ b/dist/syft.yaml
@@ -36,3 +36,5 @@ exclude:
   - ./var/run
   - ./var/lib/docker
   - ./var/lib/containerd
+  - ./var/lib/containers
+  - ./home/kubernetes/containerized_mounter # GKE

--- a/src/agent/chroot_cmd.rs
+++ b/src/agent/chroot_cmd.rs
@@ -1,0 +1,310 @@
+use std::ffi::{OsString, OsStr, CString, CStr};
+use std::os::unix::ffi::OsStringExt;
+use std::path::{PathBuf, Path};
+use std::os::fd::{AsRawFd, OwnedFd, FromRawFd, RawFd};
+
+use anyhow::{Result};
+use nix::sys::wait::WaitStatus;
+use nix::unistd::ForkResult;
+use nix::fcntl::{AtFlags, FdFlag};
+use tokio_pipe::{PipeRead, PipeWrite};
+
+
+pub struct CommandWithChroot {
+    exe: PathBuf,
+    chroot: PathBuf,
+    args: Vec<OsString>,
+    stdin_file: Option<std::fs::File>,
+    stdout_file: Option<std::fs::File>,
+    stderr_file: Option<std::fs::File>,
+}
+
+impl CommandWithChroot {
+    pub fn new(exe: PathBuf) -> Self {
+        Self {
+            exe,
+            chroot: PathBuf::from("/"),
+            args: Vec::new(),
+            stdin_file: None,
+            stdout_file: None,
+            stderr_file: None,
+        }
+    }
+
+    pub fn chroot(&mut self, root: PathBuf) -> &mut Self {
+        self.chroot = root;
+        self
+    }
+
+    pub fn arg(&mut self, a: OsString) -> &mut Self {
+        self.args.push(a);
+        self
+    }
+
+    pub fn stdin(&mut self, f: std::fs::File) -> &mut Self {
+        self.stdin_file = Some(f);
+        self
+    }
+
+    pub fn stdout(&mut self, f: std::fs::File) -> &mut Self {
+        self.stdout_file = Some(f);
+        self
+    }
+
+    pub fn stderr(&mut self, f: std::fs::File) -> &mut Self {
+        self.stderr_file = Some(f);
+        self
+    }
+
+    pub async fn run(self) -> Result<WaitStatus> {
+        let mut inp = self.stdin_file.map(|f| PipedInFile::new(f))
+            .transpose()?;
+
+        let mut outp = self.stdout_file.map(|f| PipedOutFile::new(f))
+            .transpose()?;
+
+        let mut errp = self.stderr_file.map(|f| PipedOutFile::new(f))
+            .transpose()?;
+
+        let args: Vec<CString> = self.args.into_iter()
+            .map(|s| CString::new(s.into_vec()).unwrap())
+            .collect();
+
+        let env: Vec<CString> = std::env::vars()
+            .map(|(k, v)| format!("{k}={v}"))
+            .map(|s| CString::new(s).unwrap())
+            .collect();
+
+        match unsafe { nix::unistd::fork()? } {
+            ForkResult::Parent{ child, .. } => {
+                if let Some(ref mut inp) = inp {
+                    inp.close();
+                }
+
+                if let Some(ref mut outp) = outp {
+                    outp.close();
+                }
+
+                if let Some(ref mut errp) = errp {
+                    errp.close();
+                }
+
+                let status = tokio::task::spawn_blocking(move || {
+                    nix::sys::wait::waitpid(child, None)
+                }).await??;
+
+                if let Some(inp) = inp {
+                    _ = inp.join().await;
+                }
+
+                if let Some(outp) = outp {
+                    _ = outp.join().await;
+                }
+
+                if let Some(errp) = errp {
+                    _ = errp.join().await;
+                }
+
+                Ok(status)
+
+            },
+            ForkResult::Child => {
+                // From here to execve, we have to be very careful not to touch anything
+                // that may malloc. It's a multi-threaded app and forking
+                // in mutli-threaded apps is problematic since we can't know the state
+                // of locks at the time of fork.
+                if let Some(ref mut inp) = inp {
+                    if inp.dup_to(0).is_err() {
+                        die("dup2(0) failed");
+                    }
+                } else {
+                    if clear_cloexec(0).is_err() {
+                        die("clearing FD_CLOEXEC for fd=0 failed");
+                    }
+                }
+
+                if let Some(ref mut outp) = outp {
+                    if outp.dup_to(1).is_err() {
+                        die("dup2(1) failed");
+                    }
+                } else {
+                    if clear_cloexec(1).is_err() {
+                        die("clearing FD_CLOEXEC for fd=1 failed");
+                    }
+                }
+
+                if let Some(ref mut errp) = errp {
+                    if errp.dup_to(2).is_err() {
+                        die("dup2(2) failed");
+                    }
+                } else {
+                    if clear_cloexec(2).is_err() {
+                        die("clearing FD_CLOEXEC for fd=2 failed");
+                    }
+                }
+
+                if chroot_exec(&self.exe, &self.chroot, &args, &env).is_err() {
+                    die("chroot_exec failed");
+                }
+                panic!("unreachable");
+            },
+        }
+    }
+
+}
+
+// Opens the executable, performs a chroot, executes the opened executable
+fn chroot_exec(exe: &Path, chroot: &Path, args: &[CString], env: &[CString]) -> nix::Result<()> {
+    let fd = open_file(exe)?;
+
+    if chroot != OsStr::new("/") {
+        nix::unistd::chroot(chroot)?;
+    }
+
+    nix::unistd::chdir("/")?;
+    nix::unistd::execveat(fd.as_raw_fd(), <&CStr>::default(), &args, &env, AtFlags::AT_EMPTY_PATH)?;
+    // never returns
+
+    Ok(())
+}
+
+struct PipedInFile {
+    inp: Option<PipeRead>,
+    task: tokio::task::JoinHandle<Result<PipeWrite>>,
+}
+
+impl PipedInFile {
+    fn new(file: std::fs::File) -> Result<Self> {
+        let (r, mut w) = tokio_pipe::pipe()?;
+        clear_cloexec(r.as_raw_fd())?;
+
+        let task = tokio::task::spawn(async move {
+            let mut file = tokio::fs::File::from_std(file);
+            tokio::io::copy(&mut file, &mut w).await?;
+            Ok(w)
+        });
+
+        Ok(Self {
+            inp: Some(r),
+            task,
+        })
+    }
+
+    fn dup_to(&mut self, newfd: RawFd) -> nix::Result<()> {
+        if let Some(ref inp) = self.inp {
+            let fd = nix::unistd::dup2(inp.as_raw_fd(), newfd)?;
+            self.inp = Some(PipeRead::from_raw_fd_checked(fd).unwrap());
+        }
+
+        Ok(())
+    }
+
+    fn close(&mut self) {
+        self.inp = None;
+    }
+
+    async fn join(self) -> Result<()> {
+        self.task.await??;
+        Ok(())
+    }
+}
+struct PipedOutFile {
+    outp: Option<PipeWrite>,
+    task: tokio::task::JoinHandle<Result<PipeRead>>,
+}
+
+impl PipedOutFile {
+    fn new(file: std::fs::File) -> Result<Self> {
+        let (mut r, w) = tokio_pipe::pipe()?;
+        clear_cloexec(w.as_raw_fd())?;
+
+        let task = tokio::task::spawn(async move {
+            let mut file = tokio::fs::File::from_std(file);
+            tokio::io::copy(&mut r, &mut file).await?;
+            Ok(r)
+        });
+
+        Ok(Self {
+            outp: Some(w),
+            task,
+        })
+    }
+
+    fn dup_to(&mut self, newfd: RawFd) -> nix::Result<()> {
+        if let Some(ref outp) = self.outp {
+            let fd = nix::unistd::dup2(outp.as_raw_fd(), newfd)?;
+            self.outp = Some(PipeWrite::from_raw_fd_checked(fd).unwrap());
+        }
+
+        Ok(())
+    }
+
+    fn close(&mut self) {
+        self.outp = None;
+    }
+
+    async fn join(self) -> Result<()> {
+        self.task.await??;
+        Ok(())
+    }
+}
+
+fn open_file(path: &Path) -> nix::Result<OwnedFd> {
+    // stdlib File::open insists on setting O_CLOEXEC, which we don't want.
+    let fd = nix::fcntl::open(path, nix::fcntl::OFlag::empty(), nix::sys::stat::Mode::empty())?;
+    Ok(unsafe { OwnedFd::from_raw_fd(fd) } )
+}
+
+fn clear_cloexec(fd: RawFd) -> nix::Result<()> {
+    let flags = nix::fcntl::fcntl(fd, nix::fcntl::FcntlArg::F_GETFD)?;
+    let mut flags = FdFlag::from_bits_truncate(flags);
+    flags.remove(FdFlag::FD_CLOEXEC);
+    nix::fcntl::fcntl(fd, nix::fcntl::FcntlArg::F_SETFD(flags))?;
+
+    Ok(())
+}
+
+pub struct TmpFS {
+    mountpt: PathBuf,
+}
+
+impl TmpFS {
+    pub fn mount(mountpt: PathBuf) -> Result<Self> {
+        // Mount tmpfs
+        nix::mount::mount(
+            Some("tmpfs"),
+            &mountpt,
+            Some("tmpfs"),
+            nix::mount::MsFlags::empty(),
+            Option::<&Path>::None,
+        )?;
+
+        // Disable mount propagation
+        nix::mount::mount(
+            Some("none"),
+            &mountpt,
+            Option::<&Path>::None,
+            nix::mount::MsFlags::MS_PRIVATE,
+            Option::<&Path>::None,
+        )?;
+
+        Ok(Self { mountpt })
+    }
+
+    pub fn mountpoint(&self) -> &Path {
+        &self.mountpt
+    }
+}
+
+impl Drop for TmpFS {
+    fn drop(&mut self) {
+        _ = nix::mount::umount(&self.mountpt)
+    }
+}
+
+fn die(msg: &str) {
+    // Can't use print! b/c it'll allocate.
+    // Can't use std::io::stderr() b/c it requires taking a lock.
+    _ = nix::unistd::write(2, msg.as_bytes());
+    std::process::exit(1);
+}

--- a/src/agent/containers/k8s_containerd.rs
+++ b/src/agent/containers/k8s_containerd.rs
@@ -147,7 +147,7 @@ impl K8sContainerdTracker {
         for t in resp.tasks {
             if Status::from_i32(t.status) == Some(Status::Running) {
                 if let Some(info) = containers.remove(&t.id) {
-                    events.add_container(t.container_id, info);
+                    events.add_container(t.id, info);
                 }
             }
         }

--- a/src/agent/main.rs
+++ b/src/agent/main.rs
@@ -8,6 +8,7 @@ pub mod fanotify;
 pub mod workload_mgr;
 pub mod version;
 pub mod scoped_path;
+pub mod chroot_cmd;
 
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
@@ -97,7 +98,7 @@ async fn run(args: &CliArgs) -> Result<()> {
         },
         None => {
             info!("Generating SBOM");
-            let tmp_file = sbom::generate(config.clone(), &host_root)?;
+            let tmp_file = sbom::generate(config.clone(), &host_root).await?;
             let sbom = Sbom::load(&tmp_file.path().into())?;
 
             if !args.no_sbom_upload {

--- a/src/agent/scoped_path.rs
+++ b/src/agent/scoped_path.rs
@@ -49,7 +49,7 @@ impl RootFsPath {
         self.0.display()
     }
 
-    pub fn join(&self, path: &Path) -> RootFsPath {
+    pub fn join<P: AsRef<Path>>(&self, path: P) -> RootFsPath {
         self.0.join(path).into()
     }
 


### PR DESCRIPTION
When running in a container, host FS is mounted
into /host. However pointing Syft at /host is problematic as some symlinks break. To fix it, chroot into /host prior to running Syft.