### PR TITLE
Improve in-use reporting latency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "edgebit-agent"
-version = "0.3.0+alpha1"
+version = "0.3.1+alpha1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -522,6 +533,7 @@ dependencies = [
  "libbpf-cargo",
  "libbpf-rs",
  "log",
+ "lru",
  "nix 0.26.2",
  "oci-spec",
  "podman-api",
@@ -824,6 +836,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1007,7 +1028,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
  "serde",
 ]
 
@@ -1126,6 +1147,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "lru"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03f1160296536f10c833a82dca22267d5486734230d47bf00bf435885814ba1e"
+dependencies = [
+ "hashbrown 0.13.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ realpath-ext = "0.1.2"
 async-trait = "0.1.66"
 nix = { version = "0.26", features = ["resource", "fs"] }
 tokio-pipe = "0.2.12"
+lru = "0.10.0"
 
 [build-dependencies]
 tonic-build = "0.8"

--- a/src/agent/containers/podman.rs
+++ b/src/agent/containers/podman.rs
@@ -178,13 +178,18 @@ async fn inspect_container(podman: &Podman, id: &str) -> Result<ContainerInfo> {
 
     let (start_time, end_time) = match cont_resp.state {
         Some(state) => {
-            let started = state.started_at
+            let started_at = state.started_at
                 .map(|t| t.into());
 
-            let finished = state.finished_at
-                .map(|t| t.into());
+            let finished_at = match state.status.as_deref() {
+                Some("running") | Some("paused") => None,
+                _ => {
+                    state.finished_at
+                        .map(|t| t.into())
+                }
+            };
 
-            (started, finished)
+            (started_at, finished_at)
         },
         None => (None, None)
     };

--- a/src/agent/open_monitor.rs
+++ b/src/agent/open_monitor.rs
@@ -156,7 +156,11 @@ struct ProcessInfo {
 
 impl ProcessInfo {
     fn cgroup_path(&self) -> Result<&str> {
-        let cg = std::str::from_utf8(&self.cgroup)
+        let nul = self.cgroup.iter()
+            .position(|b| *b == 0u8)
+            .unwrap_or(self.cgroup.len());
+
+        let cg = std::str::from_utf8(&self.cgroup[..nul])
             .map_err(|_| anyhow!("cgroup name with non-UTF8 characters"))?;
 
         Ok(cg)

--- a/src/agent/platform.rs
+++ b/src/agent/platform.rs
@@ -115,6 +115,7 @@ impl Client {
             workload_id,
         };
 
+        trace!("ReportInUse: {req:?}");
         self.inventory_svc.report_in_use(req).await?;
         Ok(())
     }

--- a/src/agent/registry.rs
+++ b/src/agent/registry.rs
@@ -57,6 +57,7 @@ impl Registry {
     }
 }
 
+#[derive(Debug)]
 pub struct PkgRef {
     pub id: String,
     pub filenames: Vec<WorkloadPath>,


### PR DESCRIPTION
- Batch in-use events so a single call is made every second
- Use an LRU cache to reduce sending identitcal files

Also:
- Bug fix for running containers reporting end times.