### PR TITLE
Call ResetWorkflows() on startup

### DIFF
--- a/src/agent/containers/mod.rs
+++ b/src/agent/containers/mod.rs
@@ -100,7 +100,6 @@ impl Containers {
 
                             Err(err) => error!("Failed to connect to podman: {err}"),
                         }
-
                     },
                     _ => {
                         if let Err(err) = tracker.track(ev.clone()).await {

--- a/src/agent/platform.rs
+++ b/src/agent/platform.rs
@@ -120,6 +120,11 @@ impl Client {
         Ok(())
     }
 
+    pub async fn reset_workloads(&mut self) -> Result<()> {
+        self.inventory_svc.reset_workloads(pb::ResetWorkloadsRequest{}).await?;
+        Ok(())
+    }
+
     pub async fn stop(self) {
         self.sess_keeper_task.abort();
         _ = self.sess_keeper_task.await;

--- a/src/agent/workload_mgr.rs
+++ b/src/agent/workload_mgr.rs
@@ -267,7 +267,7 @@ async fn handle_container_event(inner: &Inner, evt: ContainerEvent) {
 
 pub struct HostWorkload {
     pub id: String,
-    pub group: Vec<String>,
+    pub labels: Vec<String>,
     pub hostname: String,
     pub os_pretty_name: String,
     pub image_id: String,
@@ -308,7 +308,7 @@ impl HostWorkload {
 
         Ok(Self{
             id,
-            group: Vec::new(),
+            labels: Vec::new(),
             hostname,
             os_pretty_name,
             image_id: sbom.id(),

--- a/src/server-stub/main.rs
+++ b/src/server-stub/main.rs
@@ -87,6 +87,15 @@ impl InventoryService for Service {
         }
     }
 
+    async fn reset_workloads(
+        &self,
+        request: Request<pb::ResetWorkloadsRequest>,
+    ) -> Result<Response<pb::ResetWorkloadsResponse>, Status> {
+
+        println!("reset_workloads: {:?}", request);
+        Ok(Response::new(pb::ResetWorkloadsResponse{}))
+    }
+
     async fn upsert_workload(
         &self,
         request: Request<pb::UpsertWorkloadRequest>,


### PR DESCRIPTION
The call assures that all currently stopped containers won't show up as running in the dashboard.