### PR TITLE
Support older (<5.6) kernels

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -27,8 +27,7 @@ fn build_bpf() -> Result<(), Box<dyn std::error::Error>> {
     out.push("probes.skel.rs");
     SkeletonBuilder::new()
         .source(PROBES_SRC)
-        .clang("clang-10")
-//        .clang_args("-D__TARGET_ARCH_x86")
+        .clang("clang")
         .build_and_generate(&out)?;
     println!("cargo:rerun-if-changed={PROBES_SRC}");
     Ok(())

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update && \
         unzip \
         xutils-dev \
         jq \
-        clang-10 \
+        clang \
         libelf1 \
         protobuf-compiler \
         libprotobuf-dev \


### PR DESCRIPTION
openat2 was introduced in 5.6 so hooking it
fails on older kernels. This fixes that by
making it optional.

Older kernels also have trouble with .rodata in BPF. The exact cause is unclear but seems like an interaction of libbpf and the kernel. To work aroud that, don't printk by default (uncomment to use it to debug). That's b/c string literals introduce .rodata section.