### PR TITLE
Make containerd roots path configurable

### DIFF
--- a/dist/kube/daemonset-civo.yaml
+++ b/dist/kube/daemonset-civo.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: edgebit-agent
+  namespace: edgebit-system
+  labels: {}
+spec:
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: edgebit-agent
+  template:
+    metadata:
+      labels:
+        app: edgebit-agent
+      name: edgebit-agent
+      annotations:
+    spec:
+      securityContext:
+        runAsUser: 0
+      hostPID: true
+      containers:
+        - name: agent
+          image: "public.ecr.aws/edgebit/edgebit-agent:0.3.1"
+          imagePullPolicy: IfNotPresent
+          command:
+          resources: {}
+          ports:
+          env:
+            - name: EDGEBIT_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: edgebit-agent-config
+                  key: edgebit-url
+            - name: EDGEBIT_ID
+              valueFrom:
+                secretKeyRef:
+                    name: edgebit-agent-api-key
+                    key: edgebit-id
+                    optional: false
+            - name: EDGEBIT_HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: DOCKER_HOST
+              value: ""
+            - name: EDGEBIT_CONTAINERD_HOST
+              value: "unix:///host/run/k3s/containerd/containerd.sock"
+            - name: EDGEBIT_CONTAINERD_ROOTS
+              value: "/run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/"
+
+          volumeMounts:
+            - name: host
+              mountPath: /host
+              readOnly: true
+            - name: debugfs
+              mountPath: /sys/kernel/debug
+            - name: var-edgebit
+              mountPath: /var/lib/edgebit
+          securityContext:
+            privileged: true
+      tolerations:
+      affinity: {}
+      nodeSelector:
+        kubernetes.io/os: linux
+      volumes:
+        - name: host
+          hostPath:
+            path: /
+        - name: debugfs
+          hostPath:
+            path: /sys/kernel/debug
+        - name: var-edgebit
+          hostPath:
+            path: /var/lib/edgebit
+            type: DirectoryOrCreate
+
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate

--- a/src/agent/main.rs
+++ b/src/agent/main.rs
@@ -117,7 +117,7 @@ async fn run(args: &CliArgs) -> Result<()> {
     };
 
     let (cont_tx, cont_rx) = tokio::sync::mpsc::channel(10);
-    let mut containers = Containers::new(cloud_meta.clone(), cont_tx);
+    let mut containers = Containers::new(config.clone(), cloud_meta.clone(), cont_tx);
     if let Some(host) = config.docker_host() {
         containers.track_docker(host);
     }

--- a/src/agent/scoped_path.rs
+++ b/src/agent/scoped_path.rs
@@ -19,6 +19,10 @@ impl HostPath {
         self.0.display()
     }
 
+    pub fn join<P: AsRef<Path>>(&self, path: P) -> HostPath {
+        self.0.join(path).into()
+    }
+
     pub fn to_rootfs(&self, prefix: &RootFsPath) -> RootFsPath {
         RootFsPath(join(prefix.as_raw(), &self.0))
     }


### PR DESCRIPTION
Adds EDGEBIT_CONTAINERD_ROOTS env var and .containerd_roots config file field to configure the path where containerd stores the rootfs for containers.