### PR TITLE
Add HostToContainer mount propagation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,6 @@
-target
+target/
+builder-target/
 dist/output
 dist/syft
 *.json
+sboms/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -894,7 +894,7 @@ dependencies = [
 
 [[package]]
 name = "edgebit-agent"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "assert2",

--- a/dist/kube/daemonset.yaml
+++ b/dist/kube/daemonset.yaml
@@ -50,6 +50,7 @@ spec:
             - name: host
               mountPath: /host
               readOnly: true
+              mountPropagation: HostToContainer
             - name: debugfs
               mountPath: /sys/kernel/debug
             - name: var-edgebit

--- a/src/agent/workloads/containers.rs
+++ b/src/agent/workloads/containers.rs
@@ -79,8 +79,8 @@ impl ContainerWorkload {
     fn file_opened(&mut self, path: &WorkloadPath) {
         match self.resolve(path) {
             Ok(Some(filepath)) => {
+                // if already reported, no need to do it again
                 if !self.check_and_mark_reported(filepath.clone()) {
-                    // already reported, no need to do it again
                     let pkg = PkgRef {
                         id: String::new(),
                         filenames: vec![filepath],


### PR DESCRIPTION
Adds mount propogation to ensure that container
which were started after the agent get their rootfs mount point propagated into the agent container.

Also adds some extra tracing and fixes some typos.