### PR TITLE
Move edgebit-build to main

### DIFF
--- a/.github/workflows/upload-sbom.yaml
+++ b/.github/workflows/upload-sbom.yaml
@@ -40,7 +40,7 @@ jobs:
       - run: unzip artifacts.zip
 
       - name: Upload SBOM to EdgeBit
-        uses: edgebitio/edgebit-build@v1
+        uses: edgebitio/edgebit-build@main
         with:
           edgebit-url: https://edgebit.edgebit.io
           token: ${{ secrets.EDGEBIT_TOKEN }}


### PR DESCRIPTION
To test changes to main (how commit SHA is determined when pr-number is given), temporary move it off of v1.