### PR TITLE
Fix clippy errors (use unwrap_or_default)

### DIFF
--- a/src/agent/config.rs
+++ b/src/agent/config.rs
@@ -243,7 +243,7 @@ impl Config {
     }
 
     pub fn labels(&self) -> HashMap<String, String> {
-        let mut labels = self.inner.labels.clone().unwrap_or(HashMap::new());
+        let mut labels = self.inner.labels.clone().unwrap_or_default();
 
         if let Ok(labels_str) = std::env::var("EDGEBIT_LABELS") {
             labels.extend(labels_str.split(';').filter_map(|kv| {

--- a/src/agent/main.rs
+++ b/src/agent/main.rs
@@ -269,15 +269,15 @@ async fn handle_container_started(
             workload: Some(pb::Workload {
                 labels,
                 kind: Some(pb::workload::Kind::Container(pb::Container {
-                    name: info.name.unwrap_or(String::new()),
+                    name: info.name.unwrap_or_default(),
                 })),
             }),
             start_time: info.start_time.map(|t| t.into()),
             end_time: Some(TIMESTAMP_INFINITY),
-            image_id: info.image_id.unwrap_or(String::new()),
+            image_id: info.image_id.unwrap_or_default(),
             image: Some(pb::Image {
                 kind: Some(pb::image::Kind::Docker(pb::DockerImage {
-                    tag: info.image.unwrap_or(String::new()),
+                    tag: info.image.unwrap_or_default(),
                 })),
             }),
             machine_id: String::new(),


### PR DESCRIPTION
Looks like clippy now encourages using unwarp_or_default() instead of unwrap_or(T::new()).