### PR TITLE
actions/download-artifact clobbers files

### DIFF
--- a/.github/workflows/upload-sbom.yaml
+++ b/.github/workflows/upload-sbom.yaml
@@ -16,23 +16,23 @@ jobs:
     steps:
       - name: Download metadata
         id: metadata
-        uses: actions/download-artifact@v4-beta
+        uses: dawidd6/action-download-artifact@v2.28.0
         with:
-          run-id: ${{ github.event.workflow_run.id }}
+          run_id: ${{ github.event.workflow_run.id }}
           name: metadata.json
 
       - name: Download SBOM
         id: sbom
-        uses: actions/download-artifact@v4-beta
+        uses: dawidd6/action-download-artifact@v2.28.0
         with:
-          run-id: ${{ github.event.workflow_run.id }}
+          run_id: ${{ github.event.workflow_run.id }}
           name: sbom.spdx.json
 
       - name: Upload SBOM to EdgeBit
-        uses: edgebitio/edgebit-build@v1
+        uses: edgebitio/edgebit-build@main
         with:
           edgebit-url: https://edgebit.edgebit.io
           token: ${{ secrets.EDGEBIT_TOKEN }}
           component: edgebitio-edgebit-agent
-          sbom-file: ${{ steps.sbom.outputs.download-path }}/sbom.spdx.json
-          args-file: ${{ steps.metadata.outputs.download-path }}/metadata.json
+          sbom-file: ./sbom.spdx.json
+          args-file: ./metadata.json


### PR DESCRIPTION
The v4-beta works with run-id's but clobbers
large files. Try a third party action.