### PR TITLE
Upload SBOMs directly from release pipeline

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -82,6 +82,7 @@ jobs:
           cat > /tmp/metadata.json <<EOF
             {
               "image-id": "${{ steps.build-agent.outputs.imageid }}",
+              "image-tag": "${{ steps.meta.outputs.images }}:${{ steps.build-agent.outputs.digest }}"
               "pr-number": "${{ github.event.number }}",
               "tags": "${{ github.ref == 'refs/heads/main' && 'latest' || '' }}"
             }

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Generate SBOM from the container
         if: ${{ matrix.arch == 'amd64' }}
-        uses: eyakubovich/sbom-action@ey/add-config-input
+        uses: anchore/sbom-action@v0
         with:
           image: ${{ steps.build-agent.outputs.imageid }}
           artifact-name: sbom.spdx.json

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   build-binaries:
     permissions:
-      id-token: write  # for AWS OIDC
+      id-token: write # for AWS OIDC
 
     strategy:
       matrix:
@@ -39,7 +39,6 @@ jobs:
         with:
           mask-password: true
           registry-type: public
-
 
       - name: Building builder image
         id: build-buildier
@@ -71,7 +70,7 @@ jobs:
         if: ${{ matrix.arch == 'amd64' }}
         uses: eyakubovich/sbom-action@ey/add-config-input
         with:
-          image: ${{ steps.build-agent.outputs.digest }}
+          image: ${{ steps.build-agent.outputs.imageid }}
           artifact-name: sbom.spdx.json
           upload-artifact: true
           config: .github/edgebit/build-syft.yaml
@@ -82,7 +81,7 @@ jobs:
           cat > /tmp/metadata.json <<EOF
             {
               "image-id": "${{ steps.build-agent.outputs.imageid }}",
-              "image-tag": "${{ steps.meta.outputs.images }}:${{ steps.build-agent.outputs.digest }}"
+              "image-tag": "${{ steps.meta.outputs.tags }}",
               "pr-number": "${{ github.event.number }}",
               "tags": "${{ github.ref == 'refs/heads/main' && 'latest' || '' }}"
             }
@@ -93,14 +92,14 @@ jobs:
         with:
           name: metadata.json
           path: /tmp/metadata.json
-      
+
   docker-combine:
     needs: build-binaries
 
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
 
     permissions:
-      id-token: write  # for AWS OIDC
+      id-token: write # for AWS OIDC
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -82,6 +82,7 @@ jobs:
           tags: edgebit-agent-build
 
       - name: Building and pushing agent container
+        id: build-agent
         uses: docker/build-push-action@v3
         with:
           push: true
@@ -99,6 +100,27 @@ jobs:
           tag_name: ${{ github.ref_name }}
           files: |
             dist/output/edgebit-agent*
+
+      - name: Generate SBOM from the container
+        id: sbom
+        if: ${{ matrix.arch == 'amd64' }}
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ steps.build.outputs.imageid }}
+          output-file: /tmp/sbom.spdx.json
+          config: .github/edgebit/build-syft.yaml
+
+      - name: Upload SBOM to EdgeBit
+        if: ${{ matrix.arch == 'amd64' }}
+        uses: edgebitio/edgebit-build@main
+        with:
+          edgebit-url: https://edgebit.edgebit.io
+          token: ${{ secrets.EDGEBIT_TOKEN }}
+          sbom-file: /tmp/sbom.spdx.json
+          image-id: ${{ steps.build.outputs.imageid }}
+          image-tag: ${{ steps.meta.outputs.tags }}
+          component: edgebitio-edgebit-agent
+          tags: v${{ steps.meta.outputs.version }}
 
   docker-combine:
     needs: draft-release


### PR DESCRIPTION
This PR tweaks three things related to SBOM generation:

1. Upload SBOM directly from the release pipeline
2. Switches back to using the upstream `anchore/sbom-action@v0` action instead of the `eyakubovich/sbom-action@ey/add-config-input` fork now that the config input changes have landed.
3. Add the image-tag to the SBOM metadata used in the build pipeline