### PR TITLE
Log at info (vs error) if can't save base-os ID

### DIFF
--- a/src/agent/workloads/host.rs
+++ b/src/agent/workloads/host.rs
@@ -138,7 +138,7 @@ fn load_baseos_id() -> String {
     let id = uuid_string();
 
     if let Err(err) = std::fs::write(BASEOS_ID_PATH, &id) {
-        error!("Failed to save BaseOS workload ID to {BASEOS_ID_PATH}: {err}");
+        info!("BaseOS workload ID was not saved to {BASEOS_ID_PATH}: {err}");
     }
 
     id


### PR DESCRIPTION
On k8s deployments, there's often no volume to persist the BaseOS generated UUID. An info level log is more appropriate.

If the BaseOS UUID is not saved, it'll be regenerated on agent restart. The EdgeBit platform deals with it ok, there's a brief period of time when a machine will show multiple workloads.