### PR TITLE
Use the new style cataloger spec

### DIFF
--- a/.github/edgebit/build-syft.yaml
+++ b/.github/edgebit/build-syft.yaml
@@ -1,34 +1,4 @@
-output: syft
-
 check-for-app-update: false
 
-catalogers:
-  - alpmdb
-  - apkdb
-  - binary
-  - cocoapods
-  - conan
-  - dartlang-lock
-  - dpkgdb
-  - dotnet-deps
-  - elixir-mix-lock
-  - erlang-rebar-lock
-  - go-mod-file
-  - go-module-binary
-  - graalvm-native-image
-  - haskell
-  - java
-  - java-gradle-lockfile
-  - java-pom
-  - javascript-lock
-  - javascript-package
-  - nix-store
-  - php-composer-lock
-  - portage
-  - python-index
-  - python-package
-  - ruby-gemfile
-  - rpm-db
-  - rust-cargo-lock
-  - sbom
-  - swift-package-manager
+select-catalogers:
+  - "+rust-cargo-lock-cataloger"


### PR DESCRIPTION
Recent Syft changed how the catalogers are specified. Instead of a single "catalogers:" key, it uses
"default-catalogers:" and "select-catalogers:" keys.

Since this is for scanning an image, the "go-binary" cataloger is there by default but the "Cargo.lock" one is not and needs to be manually added.