### PR TITLE
Fix the SBOM getting tagged w/o patch version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,7 +70,7 @@ jobs:
           images: |
             public.ecr.aws/edgebit/edgebit-agent
           tags: |
-            type=semver,pattern={{major}}.{{minor}}-${{ matrix.arch }}
+            type=semver,pattern={{version}}-${{ matrix.arch }}
           flavor: |
             latest=false
 
@@ -146,8 +146,7 @@ jobs:
           images: |
             public.ecr.aws/edgebit/edgebit-agent
           tags: |
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}.{{minor}}.{{patch}}
+            type=semver,pattern={{version}}
 
       - name: Combine into multi-arch
         shell: bash


### PR DESCRIPTION
SBOMs were getting tagged like 0.5-amd64 instead of 0.5.1-amd64. As part of the fix, this will no longer tag container images with 0.5 (no patch), only with the full version (major.minor.patch).