### PR TITLE
Cancel superseded GitHub workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-binaries:
     permissions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,10 @@ on:
     tags:
       - v*
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   id-token: write
   contents: write

--- a/.github/workflows/upload-sbom.yaml
+++ b/.github/workflows/upload-sbom.yaml
@@ -8,6 +8,10 @@ on:
     types:
       - completed
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   upload:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This serves two purposes:

- cuts costs by canceling CI when pull requests are updated
- prevents issues when releasing after pull requests are merged

Elaborating on that second point, two pull requests are merged, so two release-image workflows are started as a result. The earlier one takes longer to run, however, and mutates the 'latest' tag last. This is a great example of the dangers of mutability.