### PR TITLE
dist: bump Syft to 1.18.1

### DIFF
--- a/dist/Makefile
+++ b/dist/Makefile
@@ -1,6 +1,6 @@
 export VERSION = $(shell cargo read-manifest | jq -r .version)
 DEST = output/
-SYFT_RELEASE = 1.17.0
+SYFT_RELEASE = 1.18.1
 export ARCH = $(shell uname -m)
 export GOARCH = $(shell uname -m | sed -e "s/x86_64/amd64/" -e "s/aarch64/arm64/")
 


### PR DESCRIPTION
This addresses GHSA-v778-237x-gjrc.