### PR TITLE
dist: bump Syft to 1.19.0

### DIFF
--- a/dist/Makefile
+++ b/dist/Makefile
@@ -1,6 +1,6 @@
 export VERSION = $(shell cargo read-manifest | jq -r .version)
 DEST = output/
-SYFT_RELEASE = 1.18.1
+SYFT_RELEASE = 1.19.0
 export ARCH = $(shell uname -m)
 export GOARCH = $(shell uname -m | sed -e "s/x86_64/amd64/" -e "s/aarch64/arm64/")
 


### PR DESCRIPTION
This addresses GHSA-v725-9546-7q7m, GHSA-r9px-m959-cxf4, and GHSA-w32m-9786-jp63.